### PR TITLE
Add basic validation to all class parameters

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,7 +15,8 @@ class activemq::config (
   $path    = '/etc/activemq/activemq.xml'
 ) {
 
-  # JJM FIXME Validation!
+  validate_re($path, '^/')
+
   $path_real = $path
 
   # Since this is a template, it should come _after_ all variables are set for

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,9 @@ class activemq(
   $ensure  = 'running'
 ) {
 
-  # JJM FIXME: Input Validation and support for non EL5 systems.
+  validate_re($ensure, [ '^running$', '^stopped$' ])
+  validate_re($version, '^[._0-9a-zA-Z:-]+$')
+
   $version_real = $version
   $ensure_real  = $ensure
 

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -15,7 +15,9 @@ class activemq::packages (
   $home = '/usr/share/activemq'
 ) {
 
-  # JJM FIXME Validation!
+  validate_re($version, '^[._0-9a-zA-Z:-]+$')
+  validate_re($home, '^/')
+
   $version_real = $version
   $home_real    = $home
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -14,10 +14,10 @@ class activemq::service(
   $ensure
 ) {
 
-  # JJM FIXME Validation!
+  validate_re($ensure, [ '^running$', '^stopped$' ])
+
   $ensure_real = $ensure
 
-  # JJM FIXME Manage the service
   service { 'activemq':
     ensure     => $ensure_real,
     hasstatus  => true,


### PR DESCRIPTION
Class parameters should validate their input according to the style
guide.
