### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+2013-09-26 Release 0.2.0
+
+Summary:
+
+Adds Debian osfamily support and proper testing
+
+Backwards-incompatible changes:
+
+The module no longer manages the activemq user/group
+and instead relies on the deb and rpm packages to do it.
+
+Features:
+
+- Add support for Debian osfamilies
+- Add proper spec testing
+
 2011-06-21 Jeff McCune <jeff@puppetlabs.com> - 0.1.6
 * Add webconsole setting to enable console at http://localhost:8160/admin
 

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-activemq'
-version '0.1.6'
+version '0.2.0'
 source 'git://github.com/puppetlabs/puppetlabs-activemq'
 author 'puppetlabs'
 license 'Apache Version 2.0'


### PR DESCRIPTION
```
Summary:

Adds Debian osfamily support and proper testing

Backwards-incompatible changes:

The module no longer manages the activemq user/group
and instead relies on the deb and rpm packages to do it.

Features:

- Add support for Debian osfamilies
- Add proper spec testing
```
