### PR TITLE
allow specifying actual config template

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,8 +25,6 @@ class activemq::config (
     require => Package['activemq'],
   }
 
-  $server_config_real = $server_config
-
   if $::osfamily == 'Debian' {
     $available = "/etc/activemq/instances-available/${instance}"
     $path_real = "${available}/activemq.xml"
@@ -45,13 +43,22 @@ class activemq::config (
     $path_real = $path
   }
 
+  if $server_config {
+    $source = $server_config
+    $content = undef
+  } else {
+    $source = undef
+    $content = template("${module_name}/activemq.xml.erb")
+  }
+
   # The configuration file itself.
   file { 'activemq.xml':
     ensure  => file,
     path    => $path_real,
     owner   => '0',
     group   => '0',
-    content => $server_config_real,
+    content => $content,
+    source  => $source
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,7 @@ class activemq(
   $ensure        = 'running',
   $instance      = 'activemq',
   $webconsole    = true,
-  $server_config = 'UNSET'
+  $server_config = undef,
 ) {
 
   validate_re($ensure, '^running$|^stopped$')
@@ -39,13 +39,6 @@ class activemq(
   $version_real = $version
   $ensure_real  = $ensure
   $webconsole_real = $webconsole
-
-  # Since this is a template, it should come _after_ all variables are set for
-  # this class.
-  $server_config_real = $server_config ? {
-    'UNSET' => template("${module_name}/activemq.xml.erb"),
-    default => $server_config,
-  }
 
   # Anchors for containing the implementation class
   anchor { 'activemq::begin':
@@ -60,7 +53,7 @@ class activemq(
 
   class { 'activemq::config':
     instance      => $instance,
-    server_config => $server_config_real,
+    server_config => $server_config,
     require       => Class['activemq::packages'],
     notify        => Class['activemq::service'],
   }

--- a/spec/classes/activemq_spec.rb
+++ b/spec/classes/activemq_spec.rb
@@ -67,4 +67,15 @@ describe 'activemq' do
       end
     end
   end
+
+  describe '#config' do
+    context 'template' do
+      it { should contain_file('activemq.xml').with(:content => /<authorizationEntry topic="mcollective\.>" write="mcollective" read="mcollective" admin="mcollective" \/>/, :source => nil) }
+    end
+
+    context 'source' do
+      let(:params) { { :server_config => 'puppet:///data/activemq.xml' } }
+      it { should contain_file('activemq.xml').with(:content => nil, :source => 'puppet:///data/activemq.xml') }
+    end
+  end
 end


### PR DESCRIPTION
The current server_config parameter requires you call activemq through the class definition which doesn't allow you to specify this parameter in hiera.  

I added a config_template parameter which accomplishes the same thing but does the template processing in the class instead of the calling class.

This is backwards compatible with the previous module.
