### PR TITLE
allow selection of wrapper, transports, and set passwords

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+2013-09-26 Release 0.2.0
+
+Summary:
+
+Adds Debian osfamily support and proper testing
+
+Backwards-incompatible changes:
+
+The module no longer manages the activemq user/group
+and instead relies on the deb and rpm packages to do it.
+
+Features:
+
+- Add support for Debian osfamilies
+- Add proper spec testing
+
 2011-06-21 Jeff McCune <jeff@puppetlabs.com> - 0.1.6
 * Add webconsole setting to enable console at http://localhost:8160/admin
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2013 Puppet Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-activemq'
-version '0.1.6'
+version '0.2.0'
 source 'git://github.com/puppetlabs/puppetlabs-activemq'
 author 'puppetlabs'
 license 'Apache Version 2.0'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,7 +13,8 @@
 class activemq::config (
   $server_config,
   $instance,
-  $path = '/etc/activemq/activemq.xml'
+  $path = '/etc/activemq/activemq.xml',
+  $brokername = 'localhost'
 ) {
 
   # Resource defaults
@@ -54,4 +55,32 @@ class activemq::config (
     content => $server_config_real,
   }
 
+}
+
+class activemq::webconsole(
+  $auth = true,
+  $interface = 'all',
+  $password = 'msgbusadminsecret'
+){
+
+  $real_interface = $interface ? {
+    'all' => '0.0.0.0',
+    default => $interface
+  }
+
+  file {'jetty.xml':
+    ensure  => file,
+    path    => '/etc/activemq/jetty.xml',
+    owner   => '0',
+    group   => '0',
+    content =>  template("${module_name}/jetty.xml.erb")
+  }
+
+  file {'jetty-realm.properties':
+    ensure  => file,
+    path    => '/etc/activemq/jetty-realm.properties',
+    owner   => '0',
+    group   => '0',
+    content => template("${module_name}/jetty-realm.properties.erb")
+  }
 }

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -29,7 +29,7 @@ class activemq::packages (
     file { '/etc/init.d/activemq':
       ensure  => file,
       path    => '/etc/init.d/activemq',
-      content => template("${module_name}/init/activemq"),
+      content => template("${module_name}/init/activemq.erb"),
       owner   => '0',
       group   => '0',
       mode    => '0755',

--- a/templates/activemq-stomp.xml.erb
+++ b/templates/activemq-stomp.xml.erb
@@ -1,0 +1,162 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!--
+    Use Stomp protocol
+
+    For better behavior under heavy usage, be sure to:
+
+    1. Give broker enough memory
+    2. Disable dedicated task runner
+
+    e.g. ACTIVEMQ_OPTS="-Xmx1024M -Dorg.apache.activemq.UseDedicatedTaskRunner=false"
+
+    To run ActiveMQ with this configuration add xbean:conf/activemq-stomp.xml to your command
+    e.g. $ bin/activemq console xbean:conf/activemq-stomp.xml
+ -->
+<beans
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:amq="http://activemq.apache.org/schema/core"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+  http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+    <!-- Allows us to use system properties as variables in this configuration file -->
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <value>file:${activemq.conf}/credentials.properties</value>
+        </property>
+    </bean>
+
+    <!--
+        The <broker> element is used to configure the ActiveMQ broker.
+    -->
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="<%= @brokername %>" dataDirectory="${activemq.data}">
+
+        <!--
+            For better performances use VM cursor and small memory limit.
+            For more information, see:
+
+            http://activemq.apache.org/message-cursors.html
+
+            Also, if your producer is "hanging", it's probably due to producer flow control.
+            For more information, see:
+            http://activemq.apache.org/producer-flow-control.html
+        -->
+
+        <destinationPolicy>
+            <policyMap>
+              <policyEntries>
+                <policyEntry topic=">" producerFlowControl="false">
+                  <pendingSubscriberPolicy>
+                    <vmCursor />
+                  </pendingSubscriberPolicy>
+                </policyEntry>
+                <policyEntry queue=">" producerFlowControl="false">
+                  <!-- Use VM cursor for better latency
+                       For more information, see:
+
+                       http://activemq.apache.org/message-cursors.html
+
+                  <pendingQueuePolicy>
+                    <vmQueueCursor/>
+                  </pendingQueuePolicy>
+                  -->
+                </policyEntry>
+              </policyEntries>
+            </policyMap>
+        </destinationPolicy>
+
+
+        <!--
+            The managementContext is used to configure how ActiveMQ is exposed in
+            JMX. By default, ActiveMQ uses the MBean server that is started by
+            the JVM. For more information, see:
+
+            http://activemq.apache.org/jmx.html
+        -->
+        <managementContext>
+            <managementContext createConnector="false"/>
+        </managementContext>
+
+        <!--
+            Configure message persistence for the broker. The default persistence
+            mechanism is the KahaDB store (identified by the kahaDB tag).
+            For more information, see:
+
+            http://activemq.apache.org/persistence.html
+        -->
+        <persistenceAdapter>
+            <kahaDB directory="${activemq.data}/kahadb"/>
+        </persistenceAdapter>
+
+<!-- add users for mcollective -->
+ 
+       <plugins>
+         <statisticsBrokerPlugin/>
+         <simpleAuthenticationPlugin>
+           <users>
+             <!-- change the username and password -->
+             <authenticationUser username="<%= @mcollective_username %>" password="<%= @mcollective_password %>" groups="mcollective,everyone"/>
+             <authenticationUser username="admin" password="<%= @admin_password %>" groups="mcollective,admin,everyone"/>
+           </users>
+         </simpleAuthenticationPlugin>
+ 
+         <authorizationPlugin>
+           <map>
+             <authorizationMap>
+               <authorizationEntries>
+                 <authorizationEntry queue=">" write="admins" read="admins" admin="admins" />
+                 <authorizationEntry topic=">" write="admins" read="admins" admin="admins" />
+                 <authorizationEntry topic="ActiveMQ.Advisory.>" read="everyone" write="everyone" admin="everyone"/>
+ 
+                 <!-- these maybe should be "openshift" but.... -->
+                 <authorizationEntry topic="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
+                 <authorizationEntry queue="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
+ 
+               </authorizationEntries>
+             </authorizationMap>
+           </map>
+         </authorizationPlugin>
+       </plugins>
+
+        <!--
+            The transport connectors expose ActiveMQ over a given protocol to
+            clients and other brokers. For more information, see:
+
+            http://activemq.apache.org/configuring-transports.html
+        -->
+        <transportConnectors>
+            <transportConnector name="stomp" uri="stomp://0.0.0.0:61612?transport.closeAsync=false"/>
+            <transportConnector name="stomp+nio" uri="stomp+nio://0.0.0.0:61613?transport.closeAsync=false"/>
+        </transportConnectors>
+
+    </broker>
+
+    <!--
+        Uncomment to enable Camel
+        Take a look at activemq-camel.xml for more details
+
+    <import resource="camel.xml"/>
+    -->
+
+    <!--
+        Enable web consoles, REST and Ajax APIs and demos
+        Take a look at activemq-jetty.xml for more details
+    -->
+    <import resource="jetty.xml"/>
+
+</beans>

--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -6,7 +6,7 @@
   http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd
   http://activemq.apache.org/camel/schema/spring http://activemq.apache.org/camel/schema/spring/camel-spring.xsd">
 
-<% if webconsole_real -%>
+<% if @webconsole_real -%>
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="locations">
             <value>file:${activemq.base}/conf/credentials.properties</value>
@@ -14,7 +14,7 @@
     </bean>
 
 <% end -%>
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" useJmx="true">
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="<%= @brokername %>" useJmx="true">
         <managementContext>
             <managementContext createConnector="false"/>
         </managementContext>
@@ -23,8 +23,8 @@
           <statisticsBrokerPlugin/>
           <simpleAuthenticationPlugin>
             <users>
-              <authenticationUser username="mcollective" password="marionette" groups="mcollective,everyone"/>
-              <authenticationUser username="admin" password="secret" groups="mcollective,admin,everyone"/>
+              <authenticationUser username="<%= @mcollective_username %>" password="<%= @mcollective_password %>" groups="mcollective,everyone"/>
+              <authenticationUser username="admin" password="<%= @admin_password %>" groups="mcollective,admin,everyone"/>
             </users>
           </simpleAuthenticationPlugin>
           <authorizationPlugin>
@@ -62,7 +62,7 @@
         </transportConnectors>
     </broker>
 
-<% if webconsole_real -%>
+<% if @webconsole_real -%>
       <import resource="jetty.xml"/>
 <% end -%>
 </beans>

--- a/templates/default/activemq-stomp.xml
+++ b/templates/default/activemq-stomp.xml
@@ -1,0 +1,162 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!--
+    Use Stomp protocol
+
+    For better behavior under heavy usage, be sure to:
+
+    1. Give broker enough memory
+    2. Disable dedicated task runner
+
+    e.g. ACTIVEMQ_OPTS="-Xmx1024M -Dorg.apache.activemq.UseDedicatedTaskRunner=false"
+
+    To run ActiveMQ with this configuration add xbean:conf/activemq-stomp.xml to your command
+    e.g. $ bin/activemq console xbean:conf/activemq-stomp.xml
+ -->
+<beans
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:amq="http://activemq.apache.org/schema/core"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+  http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+    <!-- Allows us to use system properties as variables in this configuration file -->
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <value>file:${activemq.conf}/credentials.properties</value>
+        </property>
+    </bean>
+
+    <!--
+        The <broker> element is used to configure the ActiveMQ broker.
+    -->
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="message1.infra.lamourine.org" dataDirectory="${activemq.data}">
+
+        <!--
+            For better performances use VM cursor and small memory limit.
+            For more information, see:
+
+            http://activemq.apache.org/message-cursors.html
+
+            Also, if your producer is "hanging", it's probably due to producer flow control.
+            For more information, see:
+            http://activemq.apache.org/producer-flow-control.html
+        -->
+
+        <destinationPolicy>
+            <policyMap>
+              <policyEntries>
+                <policyEntry topic=">" producerFlowControl="false">
+                  <pendingSubscriberPolicy>
+                    <vmCursor />
+                  </pendingSubscriberPolicy>
+                </policyEntry>
+                <policyEntry queue=">" producerFlowControl="false">
+                  <!-- Use VM cursor for better latency
+                       For more information, see:
+
+                       http://activemq.apache.org/message-cursors.html
+
+                  <pendingQueuePolicy>
+                    <vmQueueCursor/>
+                  </pendingQueuePolicy>
+                  -->
+                </policyEntry>
+              </policyEntries>
+            </policyMap>
+        </destinationPolicy>
+
+
+        <!--
+            The managementContext is used to configure how ActiveMQ is exposed in
+            JMX. By default, ActiveMQ uses the MBean server that is started by
+            the JVM. For more information, see:
+
+            http://activemq.apache.org/jmx.html
+        -->
+        <managementContext>
+            <managementContext createConnector="false"/>
+        </managementContext>
+
+        <!--
+            Configure message persistence for the broker. The default persistence
+            mechanism is the KahaDB store (identified by the kahaDB tag).
+            For more information, see:
+
+            http://activemq.apache.org/persistence.html
+        -->
+        <persistenceAdapter>
+            <kahaDB directory="${activemq.data}/kahadb"/>
+        </persistenceAdapter>
+
+<!-- add users for mcollective -->
+ 
+       <plugins>
+         <statisticsBrokerPlugin/>
+         <simpleAuthenticationPlugin>
+           <users>
+             <!-- change the username and password -->
+             <authenticationUser username="mcollective" password="msgbussecret" groups="mcollective,everyone"/>
+             <authenticationUser username="admin" password="msgadminsecret" groups="mcollective,admin,everyone"/>
+           </users>
+         </simpleAuthenticationPlugin>
+ 
+         <authorizationPlugin>
+           <map>
+             <authorizationMap>
+               <authorizationEntries>
+                 <authorizationEntry queue=">" write="admins" read="admins" admin="admins" />
+                 <authorizationEntry topic=">" write="admins" read="admins" admin="admins" />
+                 <authorizationEntry topic="ActiveMQ.Advisory.>" read="everyone" write="everyone" admin="everyone"/>
+ 
+                 <!-- these maybe should be "openshift" but.... -->
+                 <authorizationEntry topic="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
+                 <authorizationEntry queue="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
+ 
+               </authorizationEntries>
+             </authorizationMap>
+           </map>
+         </authorizationPlugin>
+       </plugins>
+
+        <!--
+            The transport connectors expose ActiveMQ over a given protocol to
+            clients and other brokers. For more information, see:
+
+            http://activemq.apache.org/configuring-transports.html
+        -->
+        <transportConnectors>
+            <transportConnector name="stomp" uri="stomp://0.0.0.0:61612?transport.closeAsync=false"/>
+            <transportConnector name="stomp+nio" uri="stomp+nio://0.0.0.0:61613?transport.closeAsync=false"/>
+        </transportConnectors>
+
+    </broker>
+
+    <!--
+        Uncomment to enable Camel
+        Take a look at activemq-camel.xml for more details
+
+    <import resource="camel.xml"/>
+    -->
+
+    <!--
+        Enable web consoles, REST and Ajax APIs and demos
+        Take a look at activemq-jetty.xml for more details
+    -->
+    <import resource="jetty.xml"/>
+
+</beans>

--- a/templates/init/activemq.erb
+++ b/templates/init/activemq.erb
@@ -24,8 +24,8 @@ ACTIVEMQ_HOME="/usr/share/activemq"
 ACTIVEMQ_ADMIN="/usr/bin/activemq-admin"
 
 # Wrapper
-WRAPPER_CMD="/usr/sbin/tanukiwrapper"
-WRAPPER_CONF="${ACTIVEMQ_HOME}/conf/activemq-wrapper.conf"
+WRAPPER_CMD="<%= @wrapper_cmd %>"
+WRAPPER_CONF="<%= @wrapper_conf %>"
 
 # Priority at which to run the wrapper.  See "man nice" for valid priorities.
 #  nice is only used if a priority is specified.

--- a/templates/jetty-realm.properties.erb
+++ b/templates/jetty-realm.properties.erb
@@ -1,0 +1,1 @@
+admin: <%= @password %>, admin

--- a/templates/jetty.xml.erb
+++ b/templates/jetty.xml.erb
@@ -1,0 +1,113 @@
+
+    <!--
+        Licensed to the Apache Software Foundation (ASF) under one or more contributor
+        license agreements. See the NOTICE file distributed with this work for additional
+        information regarding copyright ownership. The ASF licenses this file to You under
+        the Apache License, Version 2.0 (the "License"); you may not use this file except in
+        compliance with the License. You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or
+        agreed to in writing, software distributed under the License is distributed on an
+        "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+        implied. See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+    <!--
+        An embedded servlet engine for serving up the Admin consoles, REST and Ajax APIs and
+        some demos Include this file in your configuration to enable ActiveMQ web components
+        e.g. <import resource="jetty.xml"/>
+    -->
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="securityLoginService" class="org.eclipse.jetty.security.HashLoginService">
+        <property name="name" value="ActiveMQRealm" />
+        <property name="config" value="${activemq.conf}/jetty-realm.properties" />
+    </bean>
+
+    <bean id="securityConstraint" class="org.eclipse.jetty.util.security.Constraint">
+        <property name="name" value="BASIC" />
+        <property name="roles" value="admin" />
+        <property name="authenticate" value="<%= @auth.to_s %>" />
+    </bean>
+    <bean id="securityConstraintMapping" class="org.eclipse.jetty.security.ConstraintMapping">
+        <property name="constraint" ref="securityConstraint" />
+        <property name="pathSpec" value="/*" />
+    </bean>
+    <bean id="securityHandler" class="org.eclipse.jetty.security.ConstraintSecurityHandler">
+        <property name="loginService" ref="securityLoginService" />
+        <property name="authenticator">
+            <bean class="org.eclipse.jetty.security.authentication.BasicAuthenticator" />
+        </property>
+        <property name="constraintMappings">
+            <list>
+                <ref bean="securityConstraintMapping" />
+            </list>
+        </property>
+        <property name="handler">
+            <bean id="sec" class="org.eclipse.jetty.server.handler.HandlerCollection">
+                <property name="handlers">
+                    <list>
+                        <bean class="org.eclipse.jetty.webapp.WebAppContext">
+                            <property name="contextPath" value="/admin" />
+                            <property name="resourceBase" value="${activemq.home}/webapps/admin" />
+                            <property name="logUrlOnStart" value="true" />
+                        </bean>
+                        <bean class="org.eclipse.jetty.webapp.WebAppContext">
+                            <property name="contextPath" value="/demo" />
+                            <property name="resourceBase" value="${activemq.home}/webapps/demo" />
+                            <property name="logUrlOnStart" value="true" />
+                        </bean>
+                        <bean class="org.eclipse.jetty.webapp.WebAppContext">
+                            <property name="contextPath" value="/fileserver" />
+                            <property name="resourceBase" value="${activemq.home}/webapps/fileserver" />
+                            <property name="logUrlOnStart" value="true" />
+                            <property name="parentLoaderPriority" value="true" />
+                        </bean>
+                        <bean class="org.eclipse.jetty.server.handler.ResourceHandler">
+                            <property name="directoriesListed" value="false" />
+                            <property name="welcomeFiles">
+                                <list>
+                                    <value>index.html</value>
+                                </list>
+                            </property>
+                            <property name="resourceBase" value="${activemq.home}/webapps/" />
+                        </bean>
+                        <bean id="defaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler">
+                            <property name="serveIcon" value="false" />
+                        </bean>
+                    </list>
+                </property>
+            </bean>
+        </property>
+    </bean>
+
+    <bean id="contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
+    </bean>
+
+    <bean id="Server" class="org.eclipse.jetty.server.Server" init-method="start"
+        destroy-method="stop">
+
+        <property name="connectors">
+            <list>
+                <bean id="Connector" class="org.eclipse.jetty.server.nio.SelectChannelConnector">
+                    <property name="host" value="<%= @real_interface %>" />
+                    <property name="port" value="8161" />
+                </bean>
+            </list>
+        </property>
+
+        <property name="handler">
+            <bean id="handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+                <property name="handlers">
+                    <list>
+                        <ref bean="contexts" />
+                        <ref bean="securityHandler" />
+                    </list>
+                </property>
+            </bean>
+        </property>
+
+    </bean>
+
+</beans>


### PR DESCRIPTION
added controls for passwords in web console
set broker name
select transports (openwire or stomp)

This change has no effect on existing defaults or behaviors.

1) It allows setting passwords for the admin, mcollective and web console accounts
2) It allows selection of the transport protocols (openwire|stomp) from templates
3) It allows control of the webconsole listener interface
4) It allows selection of the startup wrapper (tanuki or integrated)
