### PR TITLE
make package name configurable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,6 +13,7 @@
 class activemq::config (
   $server_config,
   $instance,
+  $package,
   $path = '/etc/activemq/activemq.xml'
 ) {
 
@@ -22,7 +23,7 @@ class activemq::config (
     group   => 'activemq',
     mode    => '0644',
     notify  => Service['activemq'],
-    require => Package['activemq'],
+    require => Package[$package],
   }
 
   $server_config_real = $server_config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@
 #
 class activemq(
   $version       = 'present',
+  $package       = 'activemq',
   $ensure        = 'running',
   $instance      = 'activemq',
   $webconsole    = true,
@@ -36,6 +37,7 @@ class activemq(
   validate_re($version, '^present$|^latest$|^[._0-9a-zA-Z:-]+$')
   validate_bool($webconsole)
 
+  $package_real = $package
   $version_real = $version
   $ensure_real  = $ensure
   $webconsole_real = $webconsole
@@ -55,11 +57,13 @@ class activemq(
 
   class { 'activemq::packages':
     version => $version_real,
+    package => $package_real,
     notify  => Class['activemq::service'],
   }
 
   class { 'activemq::config':
     instance      => $instance,
+    package       => $package_real,
     server_config => $server_config_real,
     require       => Class['activemq::packages'],
     notify        => Class['activemq::service'],

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -11,14 +11,16 @@
 # Sample Usage:
 #
 class activemq::packages (
-  $version
+  $version,
+  $package
 ) {
 
   validate_re($version, '^[._0-9a-zA-Z:-]+$')
 
   $version_real = $version
+  $package_real = $package
 
-  package { 'activemq':
+  package { $package_real:
     ensure  => $version_real,
     notify  => Service['activemq'],
   }


### PR DESCRIPTION
The ActiveMQ package is not known as 'activemq' on various systems such as OpenBSD, this PR makes the package name configurable.
