### PR TITLE
set correct default ports for transport connectors stomp and openwire

### DIFF
--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -57,8 +57,8 @@
         </systemUsage>
 
         <transportConnectors>
-            <transportConnector name="openwire" uri="tcp://0.0.0.0:6166"/>
-            <transportConnector name="stomp+nio" uri="stomp://0.0.0.0:6163"/>
+            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616"/>
+            <transportConnector name="stomp+nio" uri="stomp://0.0.0.0:61613"/>
         </transportConnectors>
     </broker>
 

--- a/templates/default/activemq.xml
+++ b/templates/default/activemq.xml
@@ -49,8 +49,8 @@
         </systemUsage>
 
         <transportConnectors>
-            <transportConnector name="openwire" uri="tcp://0.0.0.0:6166"/>
-            <transportConnector name="stomp+nio" uri="stomp://0.0.0.0:6163"/>
+            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616"/>
+            <transportConnector name="stomp+nio" uri="stomp://0.0.0.0:61613"/>
         </transportConnectors>
     </broker>
 


### PR DESCRIPTION
The defaults per Apache's docs specify these as the default ports:

[Stomp](http://activemq.apache.org/stomp.html): 61613
[openwire](http://activemq.apache.org/configuring-transports.html): 61616

However, in the activemq.xml templates, stomp=6163 and openwire=6166.  Must have been a typo originally? 

This caused a few headaches when using the [puppetlabs mcollective module](https://forge.puppetlabs.com/puppetlabs/mcollective) to configure mcollective.  I know you prefer not to have  mcollective-specific configs, but these are the true defaults per Apache.  Thanks all!
