### PR TITLE
Update activemq.xml.erb

### DIFF
--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -58,7 +58,7 @@
 
         <transportConnectors>
             <transportConnector name="openwire" uri="tcp://0.0.0.0:6166"/>
-            <transportConnector name="stomp+nio" uri="stomp://0.0.0.0:6163"/>
+            <transportConnector name="stomp+nio" uri="stomp://0.0.0.0:61613"/>
         </transportConnectors>
     </broker>
 


### PR DESCRIPTION
Its should be similar to default port in puppetlabs mcollective module

cat /etc/mcollective/server.cfg 
plugin.activemq.pool.1.port = 61613
