### PR TITLE
Syntax error fix in class activemq

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,7 +30,7 @@ class activemq(
   $ensure                  = 'running',
   $instance                = 'activemq',
   $webconsole              = true,
-  $server_config           = 'UNSET'
+  $server_config           = 'UNSET',
   $mq_broker_name          = $::fqdn,
   $mq_admin_username       = 'admin',
   $mq_admin_password       = 'admin',


### PR DESCRIPTION
Fixes the following syntax error:
Error: Syntax error at 'mq_broker_name'; expected ')' at /etc/puppet/modules/activemq/manifests/init.pp:34 on node ...
