### PR TITLE
(rebase) set correct default ports for transport connectors stomp and openwire

### DIFF
--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -100,11 +100,8 @@
         </systemUsage>
 
         <transportConnectors>
-<% if @mq_cluster_brokers_real.length > 1 -%>
-            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616" />
-<% end -%>
-            <transportConnector name="openwire" uri="tcp://0.0.0.0:6166"/>
-            <transportConnector name="stomp+nio" uri="stomp://0.0.0.0:6163"/>
+            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616"/>
+            <transportConnector name="stomp+nio" uri="stomp://0.0.0.0:61613"/>
         </transportConnectors>
     </broker>
 

--- a/templates/default/activemq.xml
+++ b/templates/default/activemq.xml
@@ -49,8 +49,8 @@
         </systemUsage>
 
         <transportConnectors>
-            <transportConnector name="openwire" uri="tcp://0.0.0.0:6166"/>
-            <transportConnector name="stomp+nio" uri="stomp://0.0.0.0:6163"/>
+            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616"/>
+            <transportConnector name="stomp+nio" uri="stomp://0.0.0.0:61613"/>
         </transportConnectors>
     </broker>
 


### PR DESCRIPTION
Fixes puppetlabs/puppetlabs-activemq#27
