### PR TITLE
Update activemq.xml.erb

### DIFF
--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -42,7 +42,7 @@
           </networkConnector>
           <networkConnector
                 name="<%= @mq_broker_name %>-<%= broker %>-queues"
-                uri="static:(tcp://<% broker -%>:61616)"
+                uri="static:(tcp://<%= broker %>:61616)"
                 userName="<%= @mq_cluster_username_real %>"
                 password="<%= @mq_cluster_password_real %>"
                 duplex="false"


### PR DESCRIPTION
Without the = symbol, it is interpreted as a ruby code and no values replacement occurs