### PR TITLE
Permissions of activemq.xml

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -50,8 +50,9 @@ class activemq::config (
   file { 'activemq.xml':
     ensure  => file,
     path    => $path_real,
-    owner   => '0',
-    group   => '0',
+    owner   => 'activemq',
+    group   => 'activemq',
+    mode    => '0600',
     content => $server_config_real,
   }
 


### PR DESCRIPTION
In the current version of the module "activemq", the permissions of "/etc/activemq/instances-available/mcollective/activemq.xml" are owned by root and can be read by everyone :
-rw-rw-r-- 1 root root 6.3K Dec  2 22:12 activemq.xml

Activemq.xml can contain passwords (in my case, the simpleAuthenticationPlugin used by MCollective and the truststore/keystore passwords). 

This patch will protect activemq.xml (permission root:root / 0600).