### PR TITLE
build symlink for activemq-data dir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -55,4 +55,11 @@ class activemq::config (
     content => $server_config_real,
   }
 
+  if $::osfamily == 'RedHat' and ($version == 'present' or versioncmp($version, '5.9') < 0) {
+    file { '/usr/share/activemq/activemq-data':
+      ensure => link,
+      target => '/usr/share/activemq/data', 
+    }
+  }
+
 }


### PR DESCRIPTION
When using this module with the puppetlabs activemq rpm on an el7 box, the data dir is not setup correctly. This results in a java process that is forever stuck trying to start activemq, no ports bound, just infinite loop in the log about how the data directory can not be created.
