### PR TITLE
Development ssl

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,7 +37,7 @@ class activemq(
   $mq_cluster_username     = 'amq',
   $mq_cluster_password     = 'secret',
   $mq_cluster_brokers      = [],
-  $ssl                     = true,
+  $ssl                     = false,
 ) {
 
   validate_re($ensure, '^running$|^stopped$')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@ class activemq(
   $mq_cluster_username     = 'amq',
   $mq_cluster_password     = 'secret',
   $mq_cluster_brokers      = [],
+  $ssl                     = true,
 ) {
 
   validate_re($ensure, '^running$|^stopped$')
@@ -47,6 +48,7 @@ class activemq(
   $version_real = $version
   $ensure_real  = $ensure
   $webconsole_real = $webconsole
+  $ssl_real       = $ssl
   $mq_admin_username_real       = $mq_admin_username
   $mq_admin_password_real       = $mq_admin_password
   $mq_cluster_username_real     = $mq_cluster_username

--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -38,7 +38,11 @@
     <%- if broker != mq_broker_name -%>
           <networkConnector
                 name="<%= @mq_broker_name %>-<%= broker %>-topics"
+                <% if @ssl_real -%>
+                uri="static:(ssl://<%= broker -%>:61617)"
+                <% else -%>
                 uri="static:(tcp://<%= broker %>:61616)"
+                 <% end -%>
                 userName="<%= @mq_cluster_username_real %>"
                 password="<%= @mq_cluster_password_real %>"
                 duplex="false"
@@ -51,7 +55,11 @@
           </networkConnector>
           <networkConnector
                 name="<%= @mq_broker_name %>-<%= broker %>-queues"
+                <% if @ssl_real -%>
+                uri="static:(ssl://<%= broker -%>:61617)"
+                <% else -%>
                 uri="static:(tcp://<%= broker -%>:61616)"
+                <% end -%>
                 userName="<%= @mq_cluster_username_real %>"
                 password="<%= @mq_cluster_password_real %>"
                 duplex="false"
@@ -107,10 +115,24 @@
                 </tempUsage>
             </systemUsage>
         </systemUsage>
-
+		<% if @ssl_real -%>
+			<!--
+			configures keystores.
+			-->
+			<sslContext>
+				<sslContext
+				keyStore="keystore.jks" keyStorePassword="mcollective"
+				trustStore="truststore.jks" trustStorePassword="mcollective"
+				/>
+			</sslContext>
+		<% end -%>
         <transportConnectors>
             <transportConnector name="openwire" uri="tcp://0.0.0.0:61616"/>
             <transportConnector name="stomp+nio" uri="stomp://0.0.0.0:61613"/>
+            <% if @ssl_real -%>
+			<transportConnector name="stomp+nio+ssl" uri="stomp+nio+ssl://0.0.0.0:61614?needClientAuth=true&amp;transport.enabledProtocols=TLSv1,TLSv1.1,T
+LSv1.2"/>
+            <% end -%>
         </transportConnectors>
     </broker>
 

--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -132,6 +132,7 @@
             <% if @ssl_real -%>
 			<transportConnector name="stomp+nio+ssl" uri="stomp+nio+ssl://0.0.0.0:61614?needClientAuth=true&amp;transport.enabledProtocols=TLSv1,TLSv1.1,T
 LSv1.2"/>
+ 			<transportConnector name="openwire+ssl" uri="ssl://0.0.0.0:61617?needClientAuth=true&amp;transport.enabledProtocols=TLSv1,TLSv1.1,TLSv1.2"/>
             <% end -%>
         </transportConnectors>
     </broker>

--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -51,7 +51,7 @@
           </networkConnector>
           <networkConnector
                 name="<%= @mq_broker_name %>-<%= broker %>-queues"
-                uri="static:(tcp://<% broker -%>:61616)"
+                uri="static:(tcp://<%= broker -%>:61616)"
                 userName="<%= @mq_cluster_username_real %>"
                 password="<%= @mq_cluster_password_real %>"
                 duplex="false"

--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -18,7 +18,16 @@
         <managementContext>
             <managementContext createConnector="false"/>
         </managementContext>
+        <!--
+            Configure message persistence for the broker. The default persistence
+            mechanism is the KahaDB store (identified by the kahaDB tag).
+            For more information, see:
 
+            http://activemq.apache.org/persistence.html
+        -->
+        <persistenceAdapter>
+            <kahaDB directory="${activemq.data}/kahadb"/>
+        </persistenceAdapter>
 <% if @mq_cluster_brokers_real.length > 1 -%>
         <!--
           Configure network connectors for a network of brokers. 

--- a/templates/default/activemq.xml
+++ b/templates/default/activemq.xml
@@ -10,7 +10,17 @@
         <managementContext>
             <managementContext createConnector="false"/>
         </managementContext>
+        <!--
+            Configure message persistence for the broker. The default persistence
+            mechanism is the KahaDB store (identified by the kahaDB tag).
+            For more information, see:
 
+            http://activemq.apache.org/persistence.html
+        -->
+        <persistenceAdapter>
+            <kahaDB directory="${activemq.data}/kahadb"/>
+        </persistenceAdapter>
+        <plugins>
         <plugins>
           <statisticsBrokerPlugin/>
           <simpleAuthenticationPlugin>

--- a/templates/default/activemq.xml
+++ b/templates/default/activemq.xml
@@ -21,7 +21,6 @@
             <kahaDB directory="${activemq.data}/kahadb"/>
         </persistenceAdapter>
         <plugins>
-        <plugins>
           <statisticsBrokerPlugin/>
           <simpleAuthenticationPlugin>
             <users>


### PR DESCRIPTION
Hi! I added the following changes to the module.
- Provided the ability to use SSL in ActiveMQ, per practice as documented:

https://docs.puppetlabs.com/mcollective/deploy/standard.html#step-2-deploy-and-configure-middleware 

and here:

https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#transport-connectors

By default, SSL is disabled, as the user must setup the keystore first, as documented here:

https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq_keystores.html

Once the key store is set up, it is just the matter of setting the value to true. 
- PersistenceAdapter was missing in activemq.xml, which caused ActiveMQ not to start up. 
