### PR TITLE
Add system_user and system_group parameters to params.pp.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,14 +14,16 @@ class activemq::config (
   $server_config,
   $instance,
   $package,
+  $system_user,
+  $system_group,
   $path = '/etc/activemq/activemq.xml',
   $server_config_show_diff = 'UNSET',
 ) {
 
   # Resource defaults
   File {
-    owner   => 'activemq',
-    group   => 'activemq',
+    owner   => $system_user,
+    group   => $system_group,
     mode    => '0644',
     notify  => Service['activemq'],
     require => Package[$package],
@@ -59,8 +61,8 @@ class activemq::config (
   file { 'activemq.xml':
     ensure  => file,
     path    => $path_real,
-    owner   => 'activemq',
-    group   => 'activemq',
+    owner   => $system_user,
+    group   => $system_group,
     mode    => '0600',
     content => $server_config_real,
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,8 @@ class activemq(
   $webconsole              = $activemq::params::webconsole,
   $server_config           = $activemq::params::server_config,
   $server_config_show_diff = $activemq::params::server_config,
+  $system_user             = $activemq::params::system_user,
+  $system_group            = $activemq::params::system_group,
   $mq_broker_name          = $activemq::params::mq_broker_name,
   $mq_admin_username       = $activemq::params::mq_admin_username,
   $mq_admin_password       = $activemq::params::mq_admin_password,
@@ -94,6 +96,8 @@ class activemq(
     package                 => $package_real,
     server_config           => $server_config_real,
     server_config_show_diff => $server_config_show_diff,
+    system_user             => $system_user,
+    system_group            => $system_group,
     require                 => Class['activemq::packages'],
     notify                  => Class['activemq::service'],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,12 +15,22 @@ class activemq::params {
   $mq_cluster_brokers      = []
 
   # Debian does not include the webconsole
+  # OpenBSD system user/group differs
   case $::osfamily {
     'Debian': {
-      $webconsole = false
+      $webconsole   = false
+      $system_user  = 'activemq'
+      $system_group = 'activemq'
+    }
+    'OpenBSD': {
+      $webconsole   = true
+      $system_user  = '_activemq'
+      $system_group = '_activemq'
     }
     default: {
-      $webconsole = true
+      $webconsole   = true
+      $system_user  = 'activemq'
+      $system_group = 'activemq'
     }
   }
 }


### PR DESCRIPTION
The last merge broke activemq for me on OpenBSD. There is no
user/group "activemq", on OpenBSD its "_activemq".
The change below is to fix the breakage for me ;)

Let me know if it needs enhancements/changes.

Set the parameter for Debian and the rest of the world to "activemq",
but for OpenBSD default to the package user/group "_activemq"

Allow the parameter to be overridden in the init.pp, and
push the values, and make use of them in config.pp.
