### PR TITLE
Allow ensure to be undef

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,10 +40,8 @@ class activemq(
   $mq_cluster_brokers      = $activemq::params::mq_cluster_brokers,
 ) inherits activemq::params {
 
-  # allow $ensure to be undef
-  if $ensure {
-    validate_re($ensure, '^running$|^stopped$')
-  }
+  # allow $ensure to be undef by setting it to "UNSET"
+  validate_re($ensure, '^running$|^stopped$|^UNSET$')
   validate_re($version, '^present$|^latest$|^[~+._0-9a-zA-Z:-]+$')
   validate_bool($webconsole)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,7 +40,10 @@ class activemq(
   $mq_cluster_brokers      = $activemq::params::mq_cluster_brokers,
 ) inherits activemq::params {
 
-  validate_re($ensure, '^running$|^stopped$')
+  # allow $ensure to be undef
+  if $ensure {
+    validate_re($ensure, '^running$|^stopped$')
+  }
   validate_re($version, '^present$|^latest$|^[~+._0-9a-zA-Z:-]+$')
   validate_bool($webconsole)
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -16,15 +16,16 @@ class activemq::service(
 ) {
 
   # Allow ensure to be undef
-  if $ensure {
-    # Arrays cannot take anonymous arrays in Puppet 2.6.8
-    $v_ensure = [ '^running$', '^stopped$' ]
-    validate_re($ensure, $v_ensure)
-  }
+  # Arrays cannot take anonymous arrays in Puppet 2.6.8
+  $v_ensure = [ '^running$', '^stopped$', '^UNSET$' ]
+  validate_re($ensure, $v_ensure)
 
   validate_bool($service_enable)
 
-  $ensure_real = $ensure
+  $ensure_real = $ensure ? {
+    'UNSET' => undef,
+    default => $ensure,
+  }
 
   service { 'activemq':
     ensure     => $ensure_real,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,9 +15,12 @@ class activemq::service(
   $service_enable = $::activemq::params::service_enable
 ) {
 
-  # Arrays cannot take anonymous arrays in Puppet 2.6.8
-  $v_ensure = [ '^running$', '^stopped$' ]
-  validate_re($ensure, $v_ensure)
+  # Allow ensure to be undef
+  if $ensure {
+    # Arrays cannot take anonymous arrays in Puppet 2.6.8
+    $v_ensure = [ '^running$', '^stopped$' ]
+    validate_re($ensure, $v_ensure)
+  }
 
   validate_bool($service_enable)
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -27,8 +27,8 @@ class activemq::service(
   $ensure_real = $ensure
 
   service { 'activemq':
-    enable     => $service_enable,
     ensure     => $ensure_real,
+    enable     => $service_enable,
     hasstatus  => true,
     hasrestart => true,
     require    => Class['activemq::packages'],


### PR DESCRIPTION
We don't want puppet to always alter the state of the service - we rely on external orchestration to bring up services in a specific order in many cases.

This change allows ensure to be set to undef.
