### PR TITLE
Make mcollective user configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,8 @@ class activemq(
   $mq_cluster_username     = $activemq::params::mq_cluster_username,
   $mq_cluster_password     = $activemq::params::mq_cluster_password,
   $mq_cluster_brokers      = $activemq::params::mq_cluster_brokers,
+  $mc_username             = $activemq::params::mc_username,
+  $mc_password             = $activemq::params::mc_password,
 ) inherits activemq::params {
 
   validate_re($ensure, '^running$|^stopped$')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,8 @@ class activemq::params {
   $mq_cluster_username     = 'amq'
   $mq_cluster_password     = 'secret'
   $mq_cluster_brokers      = []
+  $mc_username             = 'mcollective'
+  $mc_password             = 'marionette'
 
   # Debian does not include the webconsole
   case $::osfamily {

--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -70,7 +70,7 @@
 <% if @mq_cluster_brokers_real.length > 1 -%>
               <authenticationUser username="<%= @mq_cluster_username_real %>" password="<%= @mq_cluster_password_real %>" groups="admins,everyone"/>
 <% end -%>
-              <authenticationUser username="mcollective" password="marionette" groups="mcollective,everyone"/>
+              <authenticationUser username="<%= @mc_username %>" password="<%= @mc_password %>" groups="mcollective,everyone"/>
               <authenticationUser username="<%= @mq_admin_username_real %>" password="<%= @mq_admin_password_real %>" groups="mcollective,admins,everyone"/>
             </users>
           </simpleAuthenticationPlugin>


### PR DESCRIPTION
This add 2 new options to the module:

 * mc_username
 * mc_password

This options could be used to specify a username and password
for the mcollective user.